### PR TITLE
feat: change DragDropQuiz to support duplicate answers for different questions

### DIFF
--- a/_static/assessment.js
+++ b/_static/assessment.js
@@ -161,7 +161,7 @@ class DragDropQuizManager {
         let totalPairs = quiz.correctPairs.length;
         
         // Check each correct pair and apply visual feedback
-        quiz.correctPairs.forEach(([descId, optionId]) => {
+        quiz.correctPairs.forEach(([descId, expectedValue]) => {
             const dropArea = document.getElementById(`${quizId}_drop_${descId}`);
             const droppedItem = dropArea.querySelector('.dropped-item');
             
@@ -169,7 +169,24 @@ class DragDropQuizManager {
             dropArea.classList.remove('correct-answer', 'incorrect-answer');
             
             if (droppedItem) {
-                if (parseInt(droppedItem.dataset.itemId) === optionId) {
+                // Compatibility for both old index-based mapping and new text-based mapping
+                let isCorrect = false;
+                if (typeof expectedValue === 'number') {
+                    // Check against index if expectedValue is a number
+                    if (parseInt(droppedItem.dataset.itemId) === expectedValue) {
+                        isCorrect = true;
+                    } else if (droppedItem.textContent.trim() === quiz.originalOptions[expectedValue].trim()) {
+                        // Fallback text check just in case
+                        isCorrect = true;
+                    }
+                } else {
+                    // It's a string natively mapped
+                    if (droppedItem.textContent.trim() === String(expectedValue).trim()) {
+                        isCorrect = true;
+                    }
+                }
+                
+                if (isCorrect) {
                     correctCount++;
                     dropArea.classList.add('correct-answer');
                 } else {

--- a/dcat_ap/DCAT_AP_Assessment.md
+++ b/dcat_ap/DCAT_AP_Assessment.md
@@ -42,7 +42,7 @@ from quadriga import colors
 
 question1 = [
     {
-        "question": "Was ist DCAT und wofür wurde es entwickelt?",
+        "question": "Was ist DCAT und wofür wurde es entwickelt? Wählen Sie alle zutreffenden Aussagen.",
         "type": "multiple_choice",
         "answers": [
             {
@@ -285,7 +285,6 @@ create_answer_box('dcat-ap-1')
 ````{admonition} Musterlösung
 :class: solution, dropdown
 
-**Musterlösung:**
 
 **1. Welchen Metadatenstandard sollte die Stadt verwenden?**
 

--- a/quadriga/assessment.py
+++ b/quadriga/assessment.py
@@ -53,14 +53,14 @@ class DragDropQuiz:
                 "partial": "Teilweise richtig: {correct} von {total} Zuordnungen sind korrekt."
             }
         
-        # Convert correct mapping to use indices for easier JavaScript handling
+        # Convert correct mapping to use indices for earlier elements, but map option texts directly
         desc_to_idx = {desc: i for i, desc in enumerate(descriptions)}
-        opt_to_idx = {opt: i for i, opt in enumerate(options)}
         
         correct_pairs = []
         for desc, opt in correct_mapping.items():
-            if desc in desc_to_idx and opt in opt_to_idx:
-                correct_pairs.append([desc_to_idx[desc], opt_to_idx[opt]])
+            if desc in desc_to_idx:
+                # We store the string `opt` instead of the index so duplicate texts work
+                correct_pairs.append([desc_to_idx[desc], opt])
         
         html_content = self._generate_html(
             quiz_id, title, descriptions, options, correct_pairs, show_feedback, feedback_messages

--- a/semantic_web/Semantic_Web_Assessment.md
+++ b/semantic_web/Semantic_Web_Assessment.md
@@ -342,8 +342,8 @@ quiz2 = DragDropQuiz()
 quiz2.create_matching_quiz(
     title="Ordnen Sie die folgenden Charakteristika der jeweiligen Web-Generation zu:",
     descriptions=[
-        "Verlinkte Webseiten",
         "Verlinkte Applikationen (z.B. Soziale Netzwerke)",
+        "Verlinkte Webseiten",
         "Verlinkte Daten (Semantic Web)"
     ],
     options=[


### PR DESCRIPTION
This pull request introduces improvements to the drag-and-drop quiz functionality, ensuring better compatibility for quizzes with duplicate option texts.

* Enhanced the answer checking logic in `DragDropQuizManager` (`_static/assessment.js`) to support both old index-based and new text-based answer mappings, improving compatibility and robustness for quizzes with duplicate option texts.

* Updated the backend quiz creation in `assessment.py` to store the correct option as text rather than index, allowing for duplicate option texts and more flexible mappings.